### PR TITLE
Expose all methods as functions with partial application

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,67 @@ render(
 )
 ```
 
+### Pointfree style
+
+All methods of `ReactDream` are available as functions that can be partially applied and then take the ReactDream object as the last argument. This makes it possible to write compositions that can then be applied to a ReactDream object. The elements of the example above could be rewritten as:
+
+```js
+import React from 'react'
+import { render } from 'react-dom'
+import { withHandlers, withState } from 'recompose'
+import { compose, omit } from 'ramda'
+import { Html, ap, contramap, map, name, of, style } from 'react-dream'
+
+const withChildren = North => South => Wrapper => ({ north, south, wrapper, ...props }) =>
+  <Wrapper {...{ ...props, ...wrapper }}>
+    <North {...{ ...props, ...north }} />
+    <South {...{ ...props, ...south }} />
+  </Wrapper>
+
+const Title = compose(
+  name('Title'),
+  style(() => ({
+    fontFamily: 'sans-serif',
+    fontSize: 18,
+  }))
+)(Html.H1)
+
+const Tagline = compose(
+  name('Tagline'),
+  style(() => ({
+    fontFamily: 'sans-serif',
+    fontSize: 13,
+  }))
+)(Html.P)
+
+const HeaderWrapper = compose(
+  map(withState('clicked', 'updateClicked', false)),
+  map(
+    withHandlers({
+      onClick: ({ clicked, updateClicked }) => () => updateClicked(!clicked),
+    })
+  ),
+  name('HeaderWrapper'),
+  style(({ clicked }) => ({
+    backgroundColor: clicked ? 'red' : 'green',
+    cursor: 'pointer',
+    padding: 15,
+  })),
+  contramap(omit(['clicked', 'updateClicked']))
+)(Html.Header)
+
+const Header = compose(
+  name('Header'),
+  contramap(({ title, tagline }) => ({
+    north: { children: title },
+    south: { children: tagline },
+  })),
+  ap(HeaderWrapper),
+  ap(Tagline),
+  ap(Title)
+)(of(withChildren))
+```
+
 ### Lifting your own component into ReactDream
 
 For example, for a ReactNative View:

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,21 @@ export { default as styleFromProps } from './styleFromProps'
 
 export { default as withStyleFromProps } from './withStyleFromProps'
 
-export { default as contramap } from './polyfills/contramap'
+export { default as addProps } from './partialApplication/addProps'
+export { default as ap } from './partialApplication/ap'
+export { default as chain } from './partialApplication/chain'
+export { default as contramap } from './partialApplication/contramap'
+export { default as debug } from './partialApplication/debug'
+export { default as fork } from './partialApplication/fork'
+export { default as log } from './partialApplication/log'
+export { default as map } from './partialApplication/map'
+export { default as name } from './partialApplication/name'
+export { default as promap } from './partialApplication/promap'
+export { default as removeProps } from './partialApplication/removeProps'
+export { default as rotate } from './partialApplication/rotate'
+export { default as scale } from './partialApplication/scale'
+export { default as style } from './partialApplication/style'
+export { default as translate } from './partialApplication/translate'
 
 export const ReactDream = _ReactDream
 export const of = _ReactDream

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,0 +1,89 @@
+import * as entrypoint from '.'
+import { equal } from 'assert'
+
+import ReactDream from './ReactDream'
+import addProps from './partialApplication/addProps'
+import ap from './partialApplication/ap'
+import chain from './partialApplication/chain'
+import contramap from './partialApplication/contramap'
+import debug from './partialApplication/debug'
+import fork from './partialApplication/fork'
+import log from './partialApplication/log'
+import map from './partialApplication/map'
+import name from './partialApplication/name'
+import promap from './partialApplication/promap'
+import removeProps from './partialApplication/removeProps'
+import rotate from './partialApplication/rotate'
+import scale from './partialApplication/scale'
+import style from './partialApplication/style'
+import translate from './partialApplication/translate'
+
+describe('entrypoint', () => {
+  it('exposes ReactDream', () => {
+    equal(ReactDream, entrypoint.ReactDream)
+  })
+
+  it('exposes addProps', () => {
+    equal(addProps, entrypoint.addProps)
+  })
+
+  it('exposes ap', () => {
+    equal(ap, entrypoint.ap)
+  })
+
+  it('exposes chain', () => {
+    equal(chain, entrypoint.chain)
+  })
+
+  it('exposes contramap', () => {
+    equal(contramap, entrypoint.contramap)
+  })
+
+  it('exposes debug', () => {
+    equal(debug, entrypoint.debug)
+  })
+
+  it('exposes fork', () => {
+    equal(fork, entrypoint.fork)
+  })
+
+  it('exposes log', () => {
+    equal(log, entrypoint.log)
+  })
+
+  it('exposes map', () => {
+    equal(map, entrypoint.map)
+  })
+
+  it('exposes name', () => {
+    equal(name, entrypoint.name)
+  })
+
+  it('exposes promap', () => {
+    equal(promap, entrypoint.promap)
+  })
+
+  it('exposes removeProps', () => {
+    equal(removeProps, entrypoint.removeProps)
+  })
+
+  it('exposes rotate', () => {
+    equal(rotate, entrypoint.rotate)
+  })
+
+  it('exposes scale', () => {
+    equal(scale, entrypoint.scale)
+  })
+
+  it('exposes style', () => {
+    equal(style, entrypoint.style)
+  })
+
+  it('exposes translate', () => {
+    equal(translate, entrypoint.translate)
+  })
+
+  it('exposes of', () => {
+    equal(ReactDream, entrypoint.of)
+  })
+})

--- a/src/partialApplication/addProps.js
+++ b/src/partialApplication/addProps.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.addProps(f)

--- a/src/partialApplication/addProps.spec.js
+++ b/src/partialApplication/addProps.spec.js
@@ -1,0 +1,12 @@
+import addProps from './addProps'
+import { equal } from 'assert'
+
+describe('partialApplication / addProps', () => {
+  it('calls .addProps of the second arg', () => {
+    const reactDream = {
+      addProps: f => f('hello,'),
+    }
+
+    equal(addProps(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/ap.js
+++ b/src/partialApplication/ap.js
@@ -1,0 +1,1 @@
+export default f => apply => apply.ap(f)

--- a/src/partialApplication/ap.spec.js
+++ b/src/partialApplication/ap.spec.js
@@ -1,0 +1,12 @@
+import ap from './ap'
+import { equal } from 'assert'
+
+describe('partialApplication / ap', () => {
+  it('calls .ap of the second arg', () => {
+    const apply = {
+      ap: f => f('hello,'),
+    }
+
+    equal(ap(arg => arg + ' allright')(apply), 'hello, allright')
+  })
+})

--- a/src/partialApplication/chain.js
+++ b/src/partialApplication/chain.js
@@ -1,0 +1,1 @@
+export default f => chainable => chainable.chain(f)

--- a/src/partialApplication/chain.spec.js
+++ b/src/partialApplication/chain.spec.js
@@ -1,0 +1,12 @@
+import chain from './chain'
+import { equal } from 'assert'
+
+describe('partialApplication / chain', () => {
+  it('calls .chain of the second arg', () => {
+    const chainable = {
+      chain: f => f('hello,'),
+    }
+
+    equal(chain(arg => arg + ' allright')(chainable), 'hello, allright')
+  })
+})

--- a/src/partialApplication/contramap.js
+++ b/src/partialApplication/contramap.js
@@ -1,0 +1,1 @@
+export default f => contravariant => contravariant.contramap(f)

--- a/src/partialApplication/contramap.spec.js
+++ b/src/partialApplication/contramap.spec.js
@@ -1,16 +1,8 @@
 import contramap from './contramap'
 import { equal } from 'assert'
 
-describe('polyfills / contramap', () => {
+describe('partialApplication / contramap', () => {
   it('calls .contramap of the second arg', () => {
-    const contravariant = {
-      contramap: f => f('hello,'),
-    }
-
-    equal(contramap(arg => arg + ' allright', contravariant), 'hello, allright')
-  })
-
-  describe('ensure curried', () => {
     const contravariant = {
       contramap: f => f('hello,'),
     }

--- a/src/partialApplication/debug.js
+++ b/src/partialApplication/debug.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.debug(f)

--- a/src/partialApplication/debug.spec.js
+++ b/src/partialApplication/debug.spec.js
@@ -1,0 +1,12 @@
+import debug from './debug'
+import { equal } from 'assert'
+
+describe('partialApplication / debug', () => {
+  it('calls .debug of the second arg', () => {
+    const reactDream = {
+      debug: f => f('hello,'),
+    }
+
+    equal(debug(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/fork.js
+++ b/src/partialApplication/fork.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.fork(f)

--- a/src/partialApplication/fork.spec.js
+++ b/src/partialApplication/fork.spec.js
@@ -1,0 +1,12 @@
+import fork from './fork'
+import { equal } from 'assert'
+
+describe('partialApplication / fork', () => {
+  it('calls .fork of the second arg', () => {
+    const reactDream = {
+      fork: f => f('hello,'),
+    }
+
+    equal(fork(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/log.js
+++ b/src/partialApplication/log.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.log(f)

--- a/src/partialApplication/log.spec.js
+++ b/src/partialApplication/log.spec.js
@@ -1,0 +1,12 @@
+import log from './log'
+import { equal } from 'assert'
+
+describe('partialApplication / log', () => {
+  it('calls .log of the second arg', () => {
+    const reactDream = {
+      log: f => f('hello,'),
+    }
+
+    equal(log(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/map.js
+++ b/src/partialApplication/map.js
@@ -1,0 +1,1 @@
+export default f => functor => functor.map(f)

--- a/src/partialApplication/map.spec.js
+++ b/src/partialApplication/map.spec.js
@@ -1,0 +1,12 @@
+import map from './map'
+import { equal } from 'assert'
+
+describe('partialApplication / map', () => {
+  it('calls .map of the second arg', () => {
+    const functor = {
+      map: f => f('hello,'),
+    }
+
+    equal(map(arg => arg + ' allright')(functor), 'hello, allright')
+  })
+})

--- a/src/partialApplication/name.js
+++ b/src/partialApplication/name.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.name(f)

--- a/src/partialApplication/name.spec.js
+++ b/src/partialApplication/name.spec.js
@@ -1,0 +1,12 @@
+import name from './name'
+import { equal } from 'assert'
+
+describe('partialApplication / name', () => {
+  it('calls .name of the second arg', () => {
+    const reactDream = {
+      name: f => f('hello,'),
+    }
+
+    equal(name(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/promap.js
+++ b/src/partialApplication/promap.js
@@ -1,0 +1,1 @@
+export default f => profunctor => profunctor.promap(f)

--- a/src/partialApplication/promap.spec.js
+++ b/src/partialApplication/promap.spec.js
@@ -1,0 +1,12 @@
+import promap from './promap'
+import { equal } from 'assert'
+
+describe('partialApplication / promap', () => {
+  it('calls .promap of the second arg', () => {
+    const profuctor = {
+      promap: f => f('hello,', 'there'),
+    }
+
+    equal(promap((arg1, arg2) => arg1 + ' allright ' + arg2)(profuctor), 'hello, allright there')
+  })
+})

--- a/src/partialApplication/removeProps.js
+++ b/src/partialApplication/removeProps.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.removeProps(f)

--- a/src/partialApplication/removeProps.spec.js
+++ b/src/partialApplication/removeProps.spec.js
@@ -1,0 +1,12 @@
+import removeProps from './removeProps'
+import { equal } from 'assert'
+
+describe('partialApplication / removeProps', () => {
+  it('calls .removeProps of the second arg', () => {
+    const reactDream = {
+      removeProps: f => f('hello,'),
+    }
+
+    equal(removeProps(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/rotate.js
+++ b/src/partialApplication/rotate.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.rotate(f)

--- a/src/partialApplication/rotate.spec.js
+++ b/src/partialApplication/rotate.spec.js
@@ -1,0 +1,12 @@
+import rotate from './rotate'
+import { equal } from 'assert'
+
+describe('partialApplication / rotate', () => {
+  it('calls .rotate of the second arg', () => {
+    const reactDream = {
+      rotate: f => f('hello,'),
+    }
+
+    equal(rotate(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/scale.js
+++ b/src/partialApplication/scale.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.scale(f)

--- a/src/partialApplication/scale.spec.js
+++ b/src/partialApplication/scale.spec.js
@@ -1,0 +1,12 @@
+import scale from './scale'
+import { equal } from 'assert'
+
+describe('partialApplication / scale', () => {
+  it('calls .scale of the second arg', () => {
+    const reactDream = {
+      scale: f => f('hello,'),
+    }
+
+    equal(scale(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/style.js
+++ b/src/partialApplication/style.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.style(f)

--- a/src/partialApplication/style.spec.js
+++ b/src/partialApplication/style.spec.js
@@ -1,0 +1,12 @@
+import style from './style'
+import { equal } from 'assert'
+
+describe('partialApplication / style', () => {
+  it('calls .style of the second arg', () => {
+    const reactDream = {
+      style: f => f('hello,'),
+    }
+
+    equal(style(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/partialApplication/translate.js
+++ b/src/partialApplication/translate.js
@@ -1,0 +1,1 @@
+export default f => reactDream => reactDream.translate(f)

--- a/src/partialApplication/translate.spec.js
+++ b/src/partialApplication/translate.spec.js
@@ -1,0 +1,12 @@
+import translate from './translate'
+import { equal } from 'assert'
+
+describe('partialApplication / translate', () => {
+  it('calls .translate of the second arg', () => {
+    const reactDream = {
+      translate: f => f('hello,'),
+    }
+
+    equal(translate(arg => arg + ' allright')(reactDream), 'hello, allright')
+  })
+})

--- a/src/polyfills/contramap.js
+++ b/src/polyfills/contramap.js
@@ -1,3 +1,0 @@
-import { curry } from 'ramda'
-
-export default curry((f, contravariant) => contravariant.contramap(f))


### PR DESCRIPTION
- [x] Document
- [x] Try out in separate project

The goal is to then be able to compose:

```js
const App = compose(
  name('App'),
  removeProps('mouse', 'now', 'rawSize'),
  ap(Layer),
  map(
    withChild(({ width, height, rotation }) => ({
      displacement: {
        x: Math.floor(width / 2),
        y: Math.floor(height / 2),
      },
      rotation,
      size: Math.floor(Math.min(width, height) / 2),
    }))
  ),
  removeProps('rotation'),
  addProps(({ width, height }) => ({
    viewBox: `0 0 ${width} ${height}`,
  })),
)(Svg.Svg)
```